### PR TITLE
feat: ability to group and filter code blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,7 +98,7 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "eval-md"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "clap",
 ]

--- a/README.md
+++ b/README.md
@@ -127,3 +127,48 @@ text, did not really spend much time on it).
 helmrepository.source.toolkit.fluxcd.io/podinfo created
 helmrelease.helm.toolkit.fluxcd.io/podinfo created
 ```
+
+### Group Filter
+
+With a special marker, key-value pairs can be defined on code blocks:
+
+
+    ```bash #group=a something=else
+    echo "This is group A"
+    ```
+    
+    ```bash #group=b
+    echo "This is group B"
+    ```
+    
+    ```bash
+    echo "This one does not belon anywhere"
+    ```
+
+Without any extra arguments, all `bash` blocks will be evaluated:
+
+```bash
+❯ ./target/release/eval-md bash a.md
+This is group A
+This is group B
+This one does not belon anywhere
+```
+
+If we want to evaluate only a specific group, we can set the filter with the
+`--group` flag:
+
+```bash
+❯ ./target/release/eval-md bash a.md --group=a
+This is group A
+
+❯ ./target/release/eval-md bash a.md --group=b
+This is group B
+```
+
+If `--group` flag is specified, but with empty value, it means evaluate
+everything that has no group.
+
+```bash
+❯ ./target/release/eval-md bash a.md --group=
+This one does not belon anywhere
+```

--- a/example/test.md
+++ b/example/test.md
@@ -14,6 +14,20 @@ echo "nice in bash"
 echo "Arguments: ${*}"
 ```
 
+### With group name
+
+```bash #group=a something
+echo "group A"
+```
+
+```bash #group=b
+echo "group B"
+```
+
+```bash #group=a other=value
+echo "group A 2nd time"
+```
+
 ## Python
 
 And we can have Python too :)

--- a/src/code_block_options.rs
+++ b/src/code_block_options.rs
@@ -1,0 +1,100 @@
+use std::str::FromStr;
+
+const CB_OPTION_GROUP: &str = "group";
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct CodeBlockOption {
+    pub key: String,
+    pub value: String,
+}
+
+impl CodeBlockOption {
+    pub fn is_group(&self) -> bool {
+        self.key == CB_OPTION_GROUP
+    }
+
+    pub fn parse_options(line: &str) -> Vec<CodeBlockOption> {
+        if !line.contains('#') {
+            return vec![]
+        }
+        let parts = line.split('#');
+        if let Some(options) = parts.last() {
+            println!(" -- {} -> {:?}", line, options);
+            let options = options.split(' ')
+                          .filter_map(|x| CodeBlockOption::from_str(x).ok())
+                          .collect::<Vec<CodeBlockOption>>();
+            options
+        } else {
+            vec![]
+        }
+    }
+}
+
+impl std::str::FromStr for CodeBlockOption {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.is_empty() {
+            return Err("empty string found for options list".into())
+        }
+        if !s.contains('=') {
+            return Ok(CodeBlockOption{key: s.into(), value: "".into()})
+        }
+        let mut parts = s.splitn(2, '=');
+        Ok(CodeBlockOption{
+            key: parts.next().unwrap().into(),
+            value: parts.next().unwrap().into()
+        })
+    }
+}
+
+pub fn find_group_name(options: Vec::<CodeBlockOption>) -> String {
+    let res = options
+        .into_iter()
+        .filter(|x| x.is_group())
+        .map(|x| x.value)
+        .collect::<Vec<String>>();
+
+    res.first().cloned().unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn new_cbo<S: Into<String>>(key: S, value: S) -> CodeBlockOption {
+        CodeBlockOption { key: key.into(), value: value.into() }
+    }
+
+    #[test]
+    fn test_code_block_option_from_str() {
+        let test_cases: Vec<(&str, Option<CodeBlockOption>)> = vec![
+            ("group=a", Some(CodeBlockOption { key: "group".into(), value: "a".into() })),
+            ("empty=", Some(CodeBlockOption { key: "empty".into(), value: "".into() })),
+            ("single", Some(CodeBlockOption { key: "single".into(), value: "".into() })),
+            ("more=than=one=eq", Some(CodeBlockOption { key: "more".into(), value: "than=one=eq".into() })),
+            ("", None),
+        ];
+
+        for case in test_cases {
+            let result = CodeBlockOption::from_str(case.0);
+            assert_eq!(result.ok(), case.1);
+        }
+    }
+
+    #[test]
+    fn test_parse_options() {
+        let test_cases: Vec<(&str, Vec<CodeBlockOption>)> = vec![
+            ("```bash", vec![]),
+            ("```bash #", vec![]),
+            ("```bash #group=a", vec![new_cbo("group", "a")]),
+            ("```bash #group=a version=3", vec![new_cbo("group", "a"), new_cbo("version", "3")]),
+            ("```bash # group=a", vec![new_cbo("group", "a")]),
+        ];
+
+        for case in test_cases {
+            let result = CodeBlockOption::parse_options(case.0);
+            assert_eq!(result, case.1);
+        }
+    }
+}


### PR DESCRIPTION
With long markdown files it is not rare to have 4-5 or more code blocks, but for different reasons under different sections of the document.

With this feature, we can specify key-value pairs on code blocks, and then filter them using the `--group` cli flag.

```
❯ ./target/release/eval-md bash a.md
This is group A
This is group B
This one does not belon anywhere

❯ ./target/release/eval-md bash a.md --group=a
This is group A

❯ ./target/release/eval-md bash a.md --group=b
This is group B

❯ ./target/release/eval-md bash a.md --group=
This one does not belon anywhere
```

Details in the `README.md` file.